### PR TITLE
Add option to not log faulty readouts

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -289,6 +289,7 @@
         <tr class="server"><td><label class="translate" for="ip">IP Address of OWFS Server:</label></td><td class="admin-icon"></td><td><input class="value" id="ip"/></td></tr>
         <tr class="server"><td><label class="translate" for="port">Port of OWFS Server:</label></td><td class="admin-icon"></td><td><input class="value number" id="port" size="5"/></td></tr>
         <tr><td><label class="translate" for="interval">Poll interval(sec):</label></td><td class="admin-icon"></td><td><input class="value number" id="interval" size="6"/></td></tr>
+        <tr><td><label class="translate" for="noStateChangeOnError">No state change on error</label></td><td class="admin-icon"></td><td><input class="value" id="noStateChangeOnError" type="checkbox"/></td></tr>
     </table>
     <h4 class="translate">Wires addresses</h4>
     <div id="values" style="width: 100%; height: calc(100% - 280px)">

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -282,6 +282,10 @@
                     <input class="value" id="interval" min="0" max="100000"/>
                     <label class="translate" for="interval">Poll interval(sec):</label>
                 </div>
+                <div class="col s12 m4">
+                    <input class="value" id="noStateChangeOnError" type="checkbox"/>
+                    <label class="translate" for="noStateChangeOnError">No state change on error</label>
+                </div>
             </div>
         </div>
         <div id="tab-devices" class="col s12 page">

--- a/io-package.json
+++ b/io-package.json
@@ -98,6 +98,7 @@
     "local":    false,
     "path":     "/mnt/1wire",
     "ip":       "127.0.0.1",
+    "noStateChangeOnError": false,
     "port":     4304,
     "interval": 30,
     "wires" : [

--- a/main.js
+++ b/main.js
@@ -346,7 +346,7 @@ function readWire(wire) {
                             if (!isNaN(val)) {
                                 adapter.setState('wires.' + wire._name, {val: val, ack: true, q: 0});
                             } else {
-                                adapter.log.warn('Cannot parse value of ' + pathfile + ': ' + result.value);
+                                adapter.log.warn('Cannot parse value of /' + wire.id + '/' + (wire.property || 'temperature') + ': ' + result.value);
                                 if (!adapter.config.noStateChangeOnError) {
                                     adapter.setState('wires.' + wire._name, {val: 0, ack: true, q: 0x42}); // sensor reports nonsense
                                 }

--- a/main.js
+++ b/main.js
@@ -317,6 +317,14 @@ function getOWFSClient(settings) {
     return client;
 }
 
+function owfs_parseFloat(s) {
+    let val = parseFloat(s);
+    if (!isNaN(val)) {
+        return val;
+    }
+    return parseFloat(s.replace(/^[\s\uFEFF\xA0\x00\x0C]+|[\s\uFEFF\xA0\x00\x0C]+$/g, ''));
+};
+
 function readWire(wire) {
     if (wire.iButton && !wire.property) wire.property = 'r_address';
     if (wire) {
@@ -342,7 +350,7 @@ function readWire(wire) {
                             adapter.setState('wires.' + wire._name, {val: (result.value == '1'), ack: true, q: 0});
                         } else {
                             // else some float value, e.g. temperature
-                            let val = parseFloat(result.value);
+                            let val = owfs_parseFloat(result.value);
                             if (!isNaN(val)) {
                                 adapter.setState('wires.' + wire._name, {val: val, ack: true, q: 0});
                             } else {
@@ -385,7 +393,7 @@ function readWire(wire) {
                             adapter.setState('wires.' + wire._name, {val: (result == '1'), ack: true, q: 0});
                         } else {
                             // else some float value, e.g. temperature
-                            let val = parseFloat(result);
+                            let val = owfs_parseFloat(result);
                             if (!isNaN(val)) {
                                 adapter.setState('wires.' + wire._name, {val: val, ack: true, q: 0});
                             } else {

--- a/main.js
+++ b/main.js
@@ -349,7 +349,9 @@ function readWire(wire) {
                     if (wire.iButton) {
                         adapter.setState('wires.' + wire._name, {val: false, ack: true, q: 0}); // sensor reports error
                     } else {
-                        adapter.setState('wires.' + wire._name, {val: 0, ack: true, q: 0x84}); // sensor reports error
+                        if (!adapter.config.noStateChangeOnError) {
+                            adapter.setState('wires.' + wire._name, {val: 0, ack: true, q: 0x84}); // sensor reports error
+                        }
                         adapter.log.warn('Cannot read value of /' + wire.id + '/' + (wire.property || 'temperature') + ': ' + err);
                     }
                 }
@@ -382,7 +384,9 @@ function readWire(wire) {
                     if (wire.iButton) {
                         adapter.setState('wires.' + wire._name, {val: false, ack: true, q: 0}); // sensor reports error
                     } else {
-                        adapter.setState('wires.' + wire._name, {val: 0, ack: true, q: 0x84}); // sensor reports error
+                        if (!adapter.config.noStateChangeOnError) {
+                            adapter.setState('wires.' + wire._name, {val: 0, ack: true, q: 0x84}); // sensor reports error
+                        }
                         adapter.log.warn('Cannot read value of ' + pathfile + ': ' + err);
                     }
                 }

--- a/main.js
+++ b/main.js
@@ -341,8 +341,16 @@ function readWire(wire) {
                         if (wire.property.indexOf('PIO') !== -1 && wire.property.indexOf('.BYTE') === -1) {
                             adapter.setState('wires.' + wire._name, {val: (result.value == '1'), ack: true, q: 0});
                         } else {
-                            // alse some float value, e.g. temperature
-                            adapter.setState('wires.' + wire._name, {val: parseFloat(result.value) || 0, ack: true, q: 0});
+                            // else some float value, e.g. temperature
+                            let val = parseFloat(result.value);
+                            if (!isNaN(val)) {
+                                adapter.setState('wires.' + wire._name, {val: val, ack: true, q: 0});
+                            } else {
+                                adapter.log.warn('Cannot parse value of ' + pathfile + ': ' + result.value);
+                                if (!adapter.config.noStateChangeOnError) {
+                                    adapter.setState('wires.' + wire._name, {val: 0, ack: true, q: 0x42}); // sensor reports nonsense
+                                }
+                            }
                         }
                     }
                 } else {
@@ -376,8 +384,16 @@ function readWire(wire) {
                         if (wire.property.indexOf('PIO') !== -1 && wire.property.indexOf('.BYTE') === -1) {
                             adapter.setState('wires.' + wire._name, {val: (result == '1'), ack: true, q: 0});
                         } else {
-                            // alse some float value, e.g. temperature
-                            adapter.setState('wires.' + wire._name, {val: parseFloat(result) || 0, ack: true, q: 0});
+                            // else some float value, e.g. temperature
+                            let val = parseFloat(result);
+                            if (!isNaN(val)) {
+                                adapter.setState('wires.' + wire._name, {val: val, ack: true, q: 0});
+                            } else {
+                                adapter.log.warn('Cannot parse value of ' + pathfile + ': ' + result);
+                                if (!adapter.config.noStateChangeOnError) {
+                                    adapter.setState('wires.' + wire._name, {val: 0, ack: true, q: 0x42}); // sensor reports nonsense
+                                }
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
This adds an option to not update a state if the sensor/owfs reports an error.

Additionally, it adds an extended parseFloat function, as I observed sometimes some stray ASCII characters before the retrieved values.

I have only tested this with a "local owserver" not with the mounted file system.

EDIT: This might fix issue #5 