### PR TITLE
Adding alarm state handling with a alarm flag to avoid overload and r…

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -291,7 +291,8 @@
         <tr class="local"><td><label class="translate" for="path">Path to OWFS mount:</label></td><td class="admin-icon"></td><td><input class="value" id="path"/></td></tr>
         <tr class="server"><td><label class="translate" for="ip">IP Address of OWFS Server:</label></td><td class="admin-icon"></td><td><input class="value" id="ip"/></td></tr>
         <tr class="server"><td><label class="translate" for="port">Port of OWFS Server:</label></td><td class="admin-icon"></td><td><input class="value number" id="port" size="5"/></td></tr>
-        <tr><td><label class="translate" for="interval">Poll interval(sec):</label></td><td class="admin-icon"></td><td><input class="value number" id="interval" size="6"/></td></tr>
+        <tr><td><label class="translate" for="interval">Poll interval(sec):</label></td><td class="admin-icon"></td><td><input class="value number" id="interval" size="4"/></td></tr>
+        <tr><td><label class="translate" for="alarm_interval">Alarm poll interval(msec / 0 = off):</label></td><td class="admin-icon"></td><td><input class="value number" id="alarm_interval" size="4"/></td></tr>
         <tr><td><label class="translate" for="noStateChangeOnError">No state change on error</label></td><td class="admin-icon"></td><td><input class="value" id="noStateChangeOnError" type="checkbox"/></td></tr>
     </table>
     <h4 class="translate">Wires addresses</h4>

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -286,6 +286,10 @@
                     <label class="translate" for="interval">Poll interval(sec):</label>
                 </div>
                 <div class="col s12 m4">
+                    <input class="value" id="alarm_interval" min="0" max="100000"/>
+                    <label class="translate" for="interval">Alarm poll interval(msec / 0 = off)</label>
+                </div>
+                <div class="col s12 m4">
                     <input class="value" id="noStateChangeOnError" type="checkbox"/>
                     <label class="translate" for="noStateChangeOnError">No state change on error</label>
                 </div>

--- a/main.js
+++ b/main.js
@@ -647,8 +647,8 @@ function main() {
               write: true, 
               desc:  "1wire alarm indication", 
               type:  "boolean", 
-              def:   false
-              role:  'state',
+              def:   false,
+              role:  'state'
             });
         });
         alarmPollingTimer = setInterval(pollAlarm, adapter.config.alarm_interval);


### PR DESCRIPTION
Adding alarm state handling with a alarm flag to avoid overload and race conditions

A pending alarm must be acknowledged by script with
setState('owfs.0.alarm', false)
once it is handled and the alarm condition is cleared
The alarm polling time can be configured and switched of with alarm_interval = 0